### PR TITLE
Optional credentials (IRSA/WebIdentity)

### DIFF
--- a/src/utils/actionUtils.ts
+++ b/src/utils/actionUtils.ts
@@ -83,11 +83,15 @@ export function getInputS3ClientConfig(): S3ClientConfig | undefined {
         return undefined
     }
 
-    const s3config = {
+    const credentials = core.getInput(Inputs.AWSAccessKeyId) ? {
         credentials: {
           accessKeyId: core.getInput(Inputs.AWSAccessKeyId),
           secretAccessKey: core.getInput(Inputs.AWSSecretAccessKey)
-        },
+        }
+    } : null
+
+    const s3config = {
+        ...credentials,
         region: core.getInput(Inputs.AWSRegion),
         endpoint: core.getInput(Inputs.AWSEndpoint),
         bucketEndpoint: core.getBooleanInput(Inputs.AWSS3BucketEndpoint),


### PR DESCRIPTION
Make credentials optional.

This allows avoiding static credentials, for example on EKS with IRSA: https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html